### PR TITLE
Fix ship HUD offset bug

### DIFF
--- a/src/main/kotlin/net/horizonsend/client/features/ShipStatusDisplay.kt
+++ b/src/main/kotlin/net/horizonsend/client/features/ShipStatusDisplay.kt
@@ -43,7 +43,7 @@ object ShipStatusDisplay {
 
                 renderer.draw(
                     s,
-                    x.toFloat() + renderer.getWidth(s), y.toFloat() + starting,
+                    x.toFloat(), y.toFloat() + starting,
                     Color.WHITE.rgb, true, m4f, it.vertexConsumers, TextRenderer.TextLayerType.NORMAL, 0, 15728880
                 )
             }


### PR DESCRIPTION
Removed the line that adds text size to the starting position of text in the ship info HUD.